### PR TITLE
i13: rework error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "howdy"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Daniil Sunyaev <dasforrum@gmail.com>"]
 edition = "2018"
 

--- a/src/add_command.rs
+++ b/src/add_command.rs
@@ -60,3 +60,20 @@ impl AddCommand {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errors_display() {
+        let file_path = String::from("path/to/file");
+        let io_error = io::Error::new(io::ErrorKind::Other, "error text");
+        let another_io_error = io::Error::new(io::ErrorKind::Other, "error text");
+
+        assert_eq!(AddCommandError::CannotOpenFile { file_path: file_path.clone(), open_error: io_error }.to_string(),
+            "cannot open journal file 'path/to/file'");
+        assert_eq!(AddCommandError::CannotWriteToFile { file_path, write_error: another_io_error }.to_string(),
+            "cannot write to journal file 'path/to/file'");
+    }
+}

--- a/src/add_command.rs
+++ b/src/add_command.rs
@@ -2,6 +2,8 @@ use chrono::prelude::*;
 use std::io::prelude::*;
 use std::fs::OpenOptions;
 use std::io;
+use std::fmt;
+use std::error::Error;
 
 use crate::daily_score::DailyScore;
 use crate::Config;
@@ -13,10 +15,28 @@ pub struct AddCommand {
     pub config: Config,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum AddCommandError {
-    CannotOpenFile { file_path: String, open_error: io::ErrorKind },
-    CannotWriteToFile { file_path: String, write_error: io::ErrorKind },
+    CannotOpenFile { file_path: String, open_error: io::Error },
+    CannotWriteToFile { file_path: String, write_error: io::Error },
+}
+
+impl std::error::Error for AddCommandError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::CannotOpenFile { file_path: _, open_error } => Some(open_error),
+            Self::CannotWriteToFile { file_path: _, write_error } => Some(write_error),
+        }
+    }
+}
+
+impl fmt::Display for AddCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::CannotOpenFile { file_path, open_error: _ } => write!(f, "{} '{}'", "cannot open journal file", file_path),
+            Self::CannotWriteToFile { file_path, write_error: _ } => write!(f, "{} '{}'", "cannot write to journal file", file_path),
+        }
+    }
 }
 
 impl AddCommand {
@@ -32,10 +52,10 @@ impl AddCommand {
             .append(true)
             .create(true)
             .open(self.config.file_path.clone())
-            .map_err(|open_error| AddCommandError::CannotOpenFile { file_path: self.config.file_path.clone(), open_error: open_error.kind() })?;
+            .map_err(|open_error| AddCommandError::CannotOpenFile { file_path: self.config.file_path.clone(), open_error: open_error })?;
 
         writeln!(file, "{}", daily_score.to_s())
-            .map_err(|write_error| AddCommandError::CannotWriteToFile { file_path: self.config.file_path.clone(), write_error: write_error.kind() })?;
+            .map_err(|write_error| AddCommandError::CannotWriteToFile { file_path: self.config.file_path.clone(), write_error: write_error })?;
 
         Ok(())
     }

--- a/src/daily_score.rs
+++ b/src/daily_score.rs
@@ -131,4 +131,12 @@ mod tests {
         assert_eq!(daily_score.score, 5);
         assert_eq!(daily_score.comment, "");
     }
+
+    #[test]
+    fn errors_display() {
+        assert_eq!(ParseError::MissingDateTime.to_string(), "datetime is missing");
+        assert_eq!(ParseError::InvalidDateTime("foo bar".to_string()).to_string(), "'foo bar' is not a valid datetime");
+        assert_eq!(ParseError::MissingScore.to_string(), "missing score");
+        assert_eq!(ParseError::InvalidScore("foo".to_string()).to_string(), "'foo' is not a valid score");
+    }
 }

--- a/src/daily_score.rs
+++ b/src/daily_score.rs
@@ -1,4 +1,5 @@
 use chrono::prelude::{DateTime, Utc};
+use std::fmt;
 
 const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S %z";
 
@@ -9,11 +10,25 @@ pub struct DailyScore {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum DailyScoreParseError {
+pub enum ParseError {
     MissingDateTime,
     InvalidDateTime(String),
     MissingScore,
     InvalidScore(String),
+}
+
+impl std::error::Error for ParseError {}
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let message = match self {
+            ParseError::MissingDateTime => "datetime is missing".to_string(),
+            ParseError::InvalidDateTime(date_string) => format!("'{}' is not a valid datetime", date_string),
+            ParseError::MissingScore => "missing score".to_string(),
+            ParseError::InvalidScore(score_string) => format!("'{}' is not a valid score", score_string),
+        };
+
+        write!(f, "{}", message)
+    }
 }
 
 impl DailyScore {
@@ -31,20 +46,20 @@ impl DailyScore {
         format!("{} {} {} {} {}", self.datetime.format(DATE_FORMAT), crate::JOURNAL_SEPARATOR, self.score, crate::JOURNAL_SEPARATOR, self.comment)
     }
 
-    pub fn parse(daily_score_string: &str) -> Result<Self, DailyScoreParseError> {
+    pub fn parse(daily_score_string: &str) -> Result<Self, ParseError> {
         let mut slice = daily_score_string.splitn(3, " | "); // TODO: use separator instead
 
         let datetime_str = slice.next()
-            .ok_or(DailyScoreParseError::MissingDateTime)?;
+            .ok_or(ParseError::MissingDateTime)?;
 
         let datetime = DateTime::parse_from_str(datetime_str, DATE_FORMAT)
-            .map_err(|_| DailyScoreParseError::InvalidDateTime(datetime_str.to_string()))?;
+            .map_err(|_| ParseError::InvalidDateTime(datetime_str.to_string()))?;
 
         let score_str = slice.next()
-            .ok_or(DailyScoreParseError::MissingScore)?;
+            .ok_or(ParseError::MissingScore)?;
 
         let score = score_str.parse::<i8>()
-            .map_err(|_| DailyScoreParseError::InvalidScore(score_str.to_string()))?;
+            .map_err(|_| ParseError::InvalidScore(score_str.to_string()))?;
 
         let comment = slice.next().unwrap_or("").to_string();
         let datetime: DateTime<Utc> = DateTime::from(datetime);
@@ -80,25 +95,25 @@ mod tests {
 
     #[test]
     fn invalid_string_parsing() {
-        assert_eq!(DailyScore::parse("").err().unwrap(), DailyScoreParseError::InvalidDateTime("".to_string()));
+        assert_eq!(DailyScore::parse("").err().unwrap(), ParseError::InvalidDateTime("".to_string()));
         assert_eq!(DailyScore::parse("fooo").err().unwrap(),
-            DailyScoreParseError::InvalidDateTime("fooo".to_string()));
+            ParseError::InvalidDateTime("fooo".to_string()));
 
         assert_eq!(DailyScore::parse("foo|").err().unwrap(),
-            DailyScoreParseError::InvalidDateTime("foo|".to_string()));
+            ParseError::InvalidDateTime("foo|".to_string()));
 
         assert_eq!(DailyScore::parse("2020-02-01 09:10:11 +0000|").err().unwrap(),
-            DailyScoreParseError::InvalidDateTime("2020-02-01 09:10:11 +0000|".to_string()));
+            ParseError::InvalidDateTime("2020-02-01 09:10:11 +0000|".to_string()));
 
-        assert_eq!(DailyScore::parse("2020-02-01 09:10:11 +0000").err().unwrap(), DailyScoreParseError::MissingScore);
+        assert_eq!(DailyScore::parse("2020-02-01 09:10:11 +0000").err().unwrap(), ParseError::MissingScore);
         assert_eq!(DailyScore::parse("2020-02-01 09:10:11 +0000 | ").err().unwrap(),
-            DailyScoreParseError::InvalidScore("".to_string()));
+            ParseError::InvalidScore("".to_string()));
 
         assert_eq!(DailyScore::parse("2020-02-01 09:10:11 +0000 | foo").err().unwrap(),
-            DailyScoreParseError::InvalidScore("foo".to_string()));
+            ParseError::InvalidScore("foo".to_string()));
 
         assert_eq!(DailyScore::parse("2020-02-01 09:10:11 +0000 | 4|").err().unwrap(),
-            DailyScoreParseError::InvalidScore("4|".to_string()));
+            ParseError::InvalidScore("4|".to_string()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt;
-use std::io;
 use std::num;
 use std::error::Error;
+use std::ops::Deref;
 
 use crate::add_command::{AddCommand, AddCommandError};
 use crate::mood_command::{MoodCommand, MoodReportType, MoodCommandError};
@@ -21,7 +21,7 @@ pub enum CliError {
     FilenameNotProvided,
     CommandNotRecognized(String),
     AddCommandArgsMissingDailyScore,
-    AddCommandArgsInvalidDailyScore { score_string: String, parse_error: std::num::ParseIntError },
+    AddCommandArgsInvalidDailyScore { score_string: String, parse_error: num::ParseIntError },
     MoodReportTypeInvalid(String),
     CommandExecutionError(Box<dyn Error>),
 }
@@ -29,7 +29,7 @@ pub enum CliError {
 impl std::error::Error for CliError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::CommandExecutionError(error) => Some(&**error), // TODO: is there more graceful way of handling this?
+            Self::CommandExecutionError(error) => Some(error.deref()),
             Self::AddCommandArgsInvalidDailyScore { score_string: _, parse_error } => Some(parse_error),
             _ => None
         }
@@ -56,56 +56,14 @@ impl fmt::Display for CliError {
 impl From<AddCommandError> for CliError {
     fn from(error: add_command::AddCommandError) -> Self {
         Self::CommandExecutionError(Box::new(error))
-
-//        let message = match error {
-//            AddCommandError::CannotOpenFile { file_path, open_error } => {
-//                let submessage = match open_error {
-//                    io::ErrorKind::PermissionDenied => "permission denied".to_string(),
-//                    _ => "unknown error".to_string(),
-//                };
-//                format!("cannot open or create journal file '{}': {}", file_path, submessage)
-//            },
-//            AddCommandError::CannotWriteToFile { file_path, write_error } => {
-//                let submessage = match write_error {
-//                    io::ErrorKind::PermissionDenied => "permission denied".to_string(),
-//                    _ => "unknown error".to_string(),
-//                };
-//                format!("cannot write to journal file '{}': {}", file_path, submessage)
-//            }
-//        };
-//
-//        CliError::CommandExecutionError(format!("add command failed:\n{}", message))
-    }
 }
-//
+
 impl From<MoodCommandError> for CliError {
     fn from(error: mood_command::MoodCommandError) -> Self {
         Self::CommandExecutionError(Box::new(error))
-//        let message = match error {
-//            MoodCommandError::CannotOpenFile { file_path, open_error } => {
-//                let submessage = match open_error {
-//                    io::ErrorKind::NotFound => "file not found".to_string(),
-//                    io::ErrorKind::PermissionDenied => "permission denied".to_string(),
-//                    _ => "unknown error".to_string(),
-//                };
-//                format!("cannot open journal file '{}': {}", file_path, submessage)
-//            },
-//            MoodCommandError::CannotReadLine { file_path } => format!("cannot read journal file '{}': unknown error", file_path),
-//            MoodCommandError::DailyScoreParseError { line, daily_score_parse_error } => {
-//                let submessage = match daily_score_parse_error {
-//                    DailyScoreParseError::MissingDateTime => "datetime is missing".to_string(),
-//                    DailyScoreParseError::InvalidDateTime(date_string) => format!("'{}' is not a valid datetime", date_string),
-//                    DailyScoreParseError::MissingScore => "missing score".to_string(),
-//                    DailyScoreParseError::InvalidScore(score_string) => format!("'{}' is not a valid score", score_string),
-//                };
-//                format!("cannot parse daily score data '{}': {}", line, submessage)
-//            }
-//        };
-//
-//        CliError::CommandExecutionError(format!("mood command failed:\n{}", message))
     }
 }
-//
+
 pub struct Config {
     pub file_path: String,
 }
@@ -170,9 +128,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::num;
-    use std::io;
-
     use crate::test_helpers::build_cli_args;
     use super::*;
 
@@ -181,7 +136,9 @@ mod tests {
         let args = Vec::new();
         let result_err = run(args.into_iter()).err().unwrap();
 
-        assert_eq!(result_err, CliError::CommandNotProvided);
+        assert!(
+            matches!(result_err, CliError::CommandNotProvided)
+        );
         assert_eq!(format!("{}", result_err), "command is not provided".to_string());
     }
 
@@ -190,7 +147,9 @@ mod tests {
         let args = build_cli_args("exec/path -f");
         let result_err = run(args.into_iter()).err().unwrap();
 
-        assert_eq!(result_err, CliError::FilenameNotProvided);
+        assert!(
+            matches!(result_err, CliError::FilenameNotProvided)
+        );
         assert_eq!(format!("{}", result_err), "'-f' option requires file path which is not provided");
     }
 
@@ -199,7 +158,9 @@ mod tests {
         let args = build_cli_args("exec/path foo");
         let result_err = run(args.into_iter()).err().unwrap();
 
-        assert_eq!(result_err, CliError::CommandNotRecognized("foo".to_string()));
+        assert!(
+            matches!(result_err, CliError::CommandNotRecognized(_))
+        );
         assert_eq!(format!("{}", result_err), "command 'foo' is not recognized");
     }
 
@@ -208,38 +169,11 @@ mod tests {
         let args = build_cli_args("exec/path add");
         let result_err = run(args.into_iter()).err().unwrap();
 
-        assert_eq!(result_err, CliError::AddCommandArgsMissingDailyScore);
+        assert!(
+            matches!(result_err, CliError::AddCommandArgsMissingDailyScore)
+        );
         assert_eq!(format!("{}", result_err),
             "daily score is not provided for add command")
-    }
-
-    #[test]
-    fn wrong_add_score_error() {
-        let args = build_cli_args("exec/path add x");
-        let result_err = run(args.into_iter()).err().unwrap();
-
-        assert_eq!(result_err,
-            CliError::AddCommandArgsInvalidDailyScore {
-                score_string: "x".to_string(),
-                parse_error: num::IntErrorKind::InvalidDigit,
-            });
-        assert_eq!(format!("{}", result_err),
-            "failed to parse daily score for add command: 'x' is not a valid integer".to_string())
-    }
-
-    #[test]
-    fn big_add_score_error() {
-        let args = build_cli_args("exec/path add 254");
-        let result_err = run(args.into_iter()).err().unwrap();
-
-        assert_eq!(result_err,
-            CliError::AddCommandArgsInvalidDailyScore {
-                score_string: "254".to_string(),
-                parse_error: num::IntErrorKind::PosOverflow,
-            });
-
-        assert_eq!(format!("{}", result_err),
-            "failed to parse daily score for add command: '254' is too big".to_string());
     }
 
     #[test]
@@ -247,53 +181,11 @@ mod tests {
         let args = build_cli_args("exec/path add -250");
         let result_err = run(args.into_iter()).err().unwrap();
 
-        assert_eq!(result_err,
-            CliError::AddCommandArgsInvalidDailyScore {
-                score_string: "-250".to_string(),
-                parse_error: num::IntErrorKind::NegOverflow,
-            });
-
+        assert!(
+            matches!(result_err, CliError::AddCommandArgsInvalidDailyScore { .. })
+        );
         assert_eq!(format!("{}", result_err),
-            "failed to parse daily score for add command: '-250' is too small".to_string());
-    }
-
-    #[test]
-    fn add_command_error_consumption() {
-        assert_eq!(
-            CliError::from(
-                AddCommandError::CannotOpenFile { file_path: "~/path".to_string(), open_error: io::ErrorKind::PermissionDenied }
-            ),
-            CliError::CommandExecutionError(
-                "add command failed:\ncannot open or create journal file '~/path': permission denied".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                AddCommandError::CannotOpenFile { file_path: "~/path".to_string(), open_error: io::ErrorKind::AddrInUse }
-            ),
-            CliError::CommandExecutionError(
-                "add command failed:\ncannot open or create journal file '~/path': unknown error".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                AddCommandError::CannotWriteToFile { file_path: "~/path".to_string(), write_error: io::ErrorKind::PermissionDenied }
-            ),
-            CliError::CommandExecutionError(
-                "add command failed:\ncannot write to journal file '~/path': permission denied".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                AddCommandError::CannotWriteToFile { file_path: "~/path".to_string(), write_error: io::ErrorKind::Unsupported }
-            ),
-            CliError::CommandExecutionError(
-                "add command failed:\ncannot write to journal file '~/path': unknown error".to_string()
-            )
-        );
+            "cannot parse daily score '-250' as int for add command".to_string());
     }
 
     #[test]
@@ -301,76 +193,11 @@ mod tests {
         let args = build_cli_args("exec/path mood mmm");
         let result_err = run(args.into_iter()).err().unwrap();
 
-        assert_eq!(result_err,
-            CliError::MoodReportTypeInvalid("mmm".to_string()));
+        assert!(
+            matches!(result_err, CliError::MoodReportTypeInvalid(_))
+        );
 
         assert_eq!(format!("{}", result_err),
             "'mmm' is not a valid mood report type".to_string());
-    }
-
-    #[test]
-    fn mood_command_error_consumption() {
-        assert_eq!(
-            CliError::from(
-                MoodCommandError::CannotOpenFile { file_path: "~/path".to_string(), open_error: io::ErrorKind::NotFound }
-            ),
-            CliError::CommandExecutionError(
-                "mood command failed:\ncannot open journal file '~/path': file not found".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                MoodCommandError::CannotOpenFile { file_path: "~/path".to_string(), open_error: io::ErrorKind::PermissionDenied }
-            ),
-            CliError::CommandExecutionError(
-                "mood command failed:\ncannot open journal file '~/path': permission denied".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                MoodCommandError::CannotReadLine { file_path: "~/path".to_string() }
-            ),
-            CliError::CommandExecutionError(
-                "mood command failed:\ncannot read journal file '~/path': unknown error".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                MoodCommandError::DailyScoreParseError {
-                    line: "11 | foo bar baz".to_string(),
-                    daily_score_parse_error: DailyScoreParseError::InvalidDateTime("11".to_string()),
-                }
-            ),
-            CliError::CommandExecutionError(
-                "mood command failed:\ncannot parse daily score data '11 | foo bar baz': '11' is not a valid datetime".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                MoodCommandError::DailyScoreParseError {
-                    line: "2020-02-01 09:10:11 +0000".to_string(),
-                    daily_score_parse_error: DailyScoreParseError::MissingScore,
-                }
-            ),
-            CliError::CommandExecutionError(
-                "mood command failed:\ncannot parse daily score data '2020-02-01 09:10:11 +0000': missing score".to_string()
-            )
-        );
-
-        assert_eq!(
-            CliError::from(
-                MoodCommandError::DailyScoreParseError {
-                    line: "2020-02-01 09:10:11 +0000 | foo |".to_string(),
-                    daily_score_parse_error: DailyScoreParseError::InvalidScore("foo |".to_string()),
-                }
-            ),
-            CliError::CommandExecutionError(
-                "mood command failed:\ncannot parse daily score data '2020-02-01 09:10:11 +0000 | foo |': 'foo |' is not a valid score".to_string()
-            )
-        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,25 @@
 use std::env;
 use std::process;
+use std::error::Error;
 
 fn main() {
     let args = env::args();
 
-    if let Err(message) = howdy::run(args) {
-        eprintln!("execution failed:\n{}", message);
+    if let Err(error) = howdy::run(args) {
+        report_error(&error);
         process::exit(1)
+    }
+}
+
+fn report_error(error: &dyn Error) {
+    eprintln!("execution failed:");
+    let mut current = error;
+    loop {
+        eprintln!("\t{}", current);
+        if current.source().is_none() {
+            break;
+        } else {
+            current = current.source().unwrap();
+        }
     }
 }

--- a/src/mood_command.rs
+++ b/src/mood_command.rs
@@ -19,7 +19,7 @@ pub enum MoodReportType {
     MovingMonthly,
 }
 
-#[derive(Debug)]//, PartialEq)]
+#[derive(Debug)]
 pub enum MoodCommandError {
     CannotOpenFile { file_path: String, open_error: io::Error },
     CannotReadLine { file_path: String, read_error: io::Error },
@@ -40,19 +40,9 @@ impl fmt::Display for MoodCommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::CannotOpenFile { file_path, open_error: _ } => write!(f, "{} '{}'", "cannot open journal file", file_path),
-            Self::CannotReadLine { file_path, read_error: _ } => write!(f, "{} '{}'", "cannot read journal file line", file_path),
+            Self::CannotReadLine { file_path, read_error: _ } => write!(f, "{} '{}'", "cannot read line from journal file", file_path),
             Self::DailyScoreParseError { line, daily_score_parse_error: _ } => write!(f, "{} '{}'", "cannot parse daily score data", line),
         }
-
-        //    MoodCommandError::CannotOpenFile { file_path, open_error } => {
-        //        let submessage = match open_error {
-        //            io::ErrorKind::NotFound => "file not found".to_string(),
-        //            io::ErrorKind::PermissionDenied => "permission denied".to_string(),
-        //            _ => "unknown error".to_string(),
-        //        };
-        //        format!("cannot open journal file '{}': {}", file_path, submessage)
-        //    },
-        //    MoodCommandError::CannotReadLine { file_path } => format!("cannot read journal file '{}': unknown error", file_path),
     }
 }
 
@@ -95,5 +85,26 @@ impl MoodCommand {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errors_display() {
+        let file_path = String::from("path/to/file");
+        let io_error = io::Error::new(io::ErrorKind::Other, "error text");
+        let another_io_error = io::Error::new(io::ErrorKind::Other, "error text");
+        let line = String::from("foo bar baz");
+        let daily_score_parse_error = daily_score::ParseError::MissingDateTime;
+
+        assert_eq!(MoodCommandError::CannotOpenFile { file_path: file_path.clone(), open_error: io_error }.to_string(),
+            "cannot open journal file 'path/to/file'");
+        assert_eq!(MoodCommandError::CannotReadLine { file_path, read_error: another_io_error }.to_string(),
+            "cannot read line from journal file 'path/to/file'");
+        assert_eq!(MoodCommandError::DailyScoreParseError { line, daily_score_parse_error }.to_string(),
+            "cannot parse daily score data 'foo bar baz'");
     }
 }

--- a/src/mood_command.rs
+++ b/src/mood_command.rs
@@ -1,6 +1,7 @@
-use std::io;
+use std::{io, fmt};
 use std::io::{BufRead, BufReader};
 use std::fs::OpenOptions;
+use std::error::Error;
 
 use crate::daily_score;
 use crate::daily_score::DailyScore;
@@ -18,11 +19,41 @@ pub enum MoodReportType {
     MovingMonthly,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]//, PartialEq)]
 pub enum MoodCommandError {
-    CannotOpenFile { file_path: String, open_error: io::ErrorKind },
-    CannotReadLine { file_path: String },
-    DailyScoreParseError { line: String, daily_score_parse_error: daily_score::DailyScoreParseError },
+    CannotOpenFile { file_path: String, open_error: io::Error },
+    CannotReadLine { file_path: String, read_error: io::Error },
+    DailyScoreParseError { line: String, daily_score_parse_error: daily_score::ParseError },
+}
+
+impl std::error::Error for MoodCommandError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::CannotOpenFile { file_path: _, open_error } => Some(open_error),
+            Self::CannotReadLine { file_path: _, read_error } => Some(read_error),
+            Self::DailyScoreParseError { line: _, daily_score_parse_error } => Some(daily_score_parse_error),
+        }
+    }
+}
+
+impl fmt::Display for MoodCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::CannotOpenFile { file_path, open_error: _ } => write!(f, "{} '{}'", "cannot open journal file", file_path),
+            Self::CannotReadLine { file_path, read_error: _ } => write!(f, "{} '{}'", "cannot read journal file line", file_path),
+            Self::DailyScoreParseError { line, daily_score_parse_error: _ } => write!(f, "{} '{}'", "cannot parse daily score data", line),
+        }
+
+        //    MoodCommandError::CannotOpenFile { file_path, open_error } => {
+        //        let submessage = match open_error {
+        //            io::ErrorKind::NotFound => "file not found".to_string(),
+        //            io::ErrorKind::PermissionDenied => "permission denied".to_string(),
+        //            _ => "unknown error".to_string(),
+        //        };
+        //        format!("cannot open journal file '{}': {}", file_path, submessage)
+        //    },
+        //    MoodCommandError::CannotReadLine { file_path } => format!("cannot read journal file '{}': unknown error", file_path),
+    }
 }
 
 impl MoodCommand {
@@ -32,11 +63,18 @@ impl MoodCommand {
         let file = OpenOptions::new()
             .read(true)
             .open(self.config.file_path.as_str())
-            .map_err(|open_error| MoodCommandError::CannotOpenFile { file_path: self.config.file_path.clone(), open_error: open_error.kind() })?;
+            .map_err(|open_error| MoodCommandError::CannotOpenFile {
+                file_path: self.config.file_path.clone(),
+                open_error,
+            })?;
 
         let reader = BufReader::new(file);
         for line in reader.lines() {
-            let line_string = line.map_err(|_| MoodCommandError::CannotReadLine { file_path: self.config.file_path.clone() })?;
+            let line_string = line.map_err(|read_error| MoodCommandError::CannotReadLine {
+                file_path: self.config.file_path.clone(),
+                read_error,
+            })?;
+
             let daily_score =
                 DailyScore::parse(line_string.as_str())
                 .map_err(|daily_score_parse_error|

--- a/todo
+++ b/todo
@@ -10,7 +10,7 @@
 10. ✓ allow to optionally specify filename
 11. ✗ extract daily score creation methods to factory or builder object
 12. ✓ allow to specify mood report type
-13. make sure lib errors implement std::error::Error
+13. ✓ make sure lib errors implement std::error::Error
 14. add couple of integrational tests
 15. ✓ get rid of passing iterator to lib objects; use slices or structs
 16. think of moving CliError to separate file


### PR DESCRIPTION
- use std::error::Error for error types
- store error messages on each level, and consume the error tree dynamically during report