### PR TITLE
I19/use local dates for report purposes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "howdy"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "howdy"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Daniil Sunyaev <dasforrum@gmail.com>"]
 edition = "2018"
 

--- a/src/add_command.rs
+++ b/src/add_command.rs
@@ -41,10 +41,11 @@ impl fmt::Display for AddCommandError {
 
 impl AddCommand {
     pub fn run(&self) -> Result<(), AddCommandError> {
+        let local_datetime = self.datetime.unwrap_or_else(Local::now);
         let daily_score = DailyScore {
             score: self.score,
             comment: self.comment.clone().unwrap_or_else(String::new),
-            datetime: self.datetime.unwrap_or_else(Local::now),
+            datetime: local_datetime.with_timezone(local_datetime.offset())
         };
 
         let mut file = OpenOptions::new()

--- a/src/add_command.rs
+++ b/src/add_command.rs
@@ -10,7 +10,7 @@ use crate::Config;
 
 pub struct AddCommand {
     pub score: i8,
-    pub datetime: Option<DateTime<Utc>>,
+    pub datetime: Option<DateTime<Local>>,
     pub comment: Option<String>,
     pub config: Config,
 }
@@ -44,7 +44,7 @@ impl AddCommand {
         let daily_score = DailyScore {
             score: self.score,
             comment: self.comment.clone().unwrap_or_else(String::new),
-            datetime: self.datetime.unwrap_or_else(Utc::now),
+            datetime: self.datetime.unwrap_or_else(Local::now),
         };
 
         let mut file = OpenOptions::new()

--- a/src/daily_score.rs
+++ b/src/daily_score.rs
@@ -1,12 +1,15 @@
-use chrono::prelude::{DateTime, Local};
+use chrono::prelude::{DateTime, FixedOffset};
 use std::fmt;
+
+#[cfg(test)]
+use chrono::prelude::Utc;
 
 const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S %z";
 
 pub struct DailyScore {
     pub score: i8,
     pub comment: String,
-    pub datetime: DateTime<Local>,
+    pub datetime: DateTime<FixedOffset>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -34,7 +37,7 @@ impl fmt::Display for ParseError {
 impl DailyScore {
     #[cfg(test)]
     pub fn new() -> Self {
-        Self { score: 0, comment: "".to_string(), datetime: Local::now() }
+        Self { score: 0, comment: "".to_string(), datetime: Utc::now().into() }
     }
 
     #[cfg(test)]
@@ -62,23 +65,22 @@ impl DailyScore {
             .map_err(|_| ParseError::InvalidScore(score_str.to_string()))?;
 
         let comment = slice.next().unwrap_or("").to_string();
-        let datetime: DateTime<Local> = DateTime::from(datetime);
         Ok(DailyScore { score, comment, datetime })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use chrono::prelude::{TimeZone, Utc, FixedOffset};
+    use chrono::prelude::TimeZone;
 
     use super::*;
 
     #[test]
     fn string_formatting() {
-        let local_date = FixedOffset::east(3 * 3600).ymd(2020, 1, 1).and_hms(9, 10, 11);
+        let local_date = FixedOffset::east(4 * 3600).ymd(2020, 1, 1).and_hms(9, 10, 11);
         let score = DailyScore { score: 1, comment: "foo || bar".to_string(), datetime: local_date.into() };
 
-        assert_eq!(score.to_s(), "2020-01-01 09:10:11 +0300 | 1 | foo || bar")
+        assert_eq!(score.to_s(), "2020-01-01 09:10:11 +0400 | 1 | foo || bar")
     }
 
     #[test]

--- a/src/daily_score.rs
+++ b/src/daily_score.rs
@@ -1,4 +1,4 @@
-use chrono::prelude::{DateTime, Utc};
+use chrono::prelude::{DateTime, Local};
 use std::fmt;
 
 const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S %z";
@@ -6,7 +6,7 @@ const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S %z";
 pub struct DailyScore {
     pub score: i8,
     pub comment: String,
-    pub datetime: DateTime<Utc>,
+    pub datetime: DateTime<Local>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -34,7 +34,7 @@ impl fmt::Display for ParseError {
 impl DailyScore {
     #[cfg(test)]
     pub fn new() -> Self {
-        Self { score: 0, comment: "".to_string(), datetime: Utc::now() }
+        Self { score: 0, comment: "".to_string(), datetime: Local::now() }
     }
 
     #[cfg(test)]
@@ -62,27 +62,28 @@ impl DailyScore {
             .map_err(|_| ParseError::InvalidScore(score_str.to_string()))?;
 
         let comment = slice.next().unwrap_or("").to_string();
-        let datetime: DateTime<Utc> = DateTime::from(datetime);
+        let datetime: DateTime<Local> = DateTime::from(datetime);
         Ok(DailyScore { score, comment, datetime })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use chrono::prelude::TimeZone;
+    use chrono::prelude::{TimeZone, Utc, FixedOffset};
 
     use super::*;
 
     #[test]
     fn string_formatting() {
-        let score = DailyScore { score: 1, comment: "foo || bar".to_string(), datetime: Utc.ymd(2020, 1, 1).and_hms(9, 10, 11) };
+        let local_date = FixedOffset::east(3 * 3600).ymd(2020, 1, 1).and_hms(9, 10, 11);
+        let score = DailyScore { score: 1, comment: "foo || bar".to_string(), datetime: local_date.into() };
 
-        assert_eq!(score.to_s(), "2020-01-01 09:10:11 +0000 | 1 | foo || bar")
+        assert_eq!(score.to_s(), "2020-01-01 09:10:11 +0300 | 1 | foo || bar")
     }
 
     #[test]
     fn string_parsing() {
-        let daily_score_string = "2020-02-01 09:10:11 +0000 | 1 | foo || bar";
+        let daily_score_string = "2020-02-01 09:10:11 +0200 | 1 | foo || bar";
         let daily_score_parse_result = DailyScore::parse(daily_score_string);
 
         assert!(daily_score_parse_result.is_ok());
@@ -90,7 +91,7 @@ mod tests {
         let daily_score = daily_score_parse_result.unwrap();
         assert_eq!(daily_score.score, 1);
         assert_eq!(daily_score.comment, "foo || bar");
-        assert_eq!(Utc.ymd(2020, 2, 1).and_hms(9, 10, 11), daily_score.datetime);
+        assert_eq!(Utc.ymd(2020, 2, 1).and_hms(7, 10, 11), daily_score.datetime);
     }
 
     #[test]

--- a/src/mood_report.rs
+++ b/src/mood_report.rs
@@ -75,6 +75,7 @@ impl MoodReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{Utc, FixedOffset, DateTime};
 
     #[test]
     fn builds_default() {
@@ -106,7 +107,7 @@ mod tests {
         let daily_score = DailyScore::with_score(1);
         let another_daily_score = DailyScore::with_score(2);
         let old_daily_score =
-            DailyScore { score: 5, comment: "".to_string(), datetime: Local::now() - Duration::days(40) };
+            DailyScore { score: 5, comment: "".to_string(), datetime: now_with_fixed_offset() - Duration::days(40) };
 
         let mood_report =
             MoodReport::from_daily_scores(vec![daily_score, another_daily_score, old_daily_score]);
@@ -118,11 +119,11 @@ mod tests {
     fn thirty_days_moving_mood() {
         let today_daily_score = DailyScore::with_score(1);
         let beginning_of_month_daily_score =
-            DailyScore { score: -1, comment: "".to_string(), datetime: Local::now() - Duration::days(25) - Duration::minutes(1) };
+            DailyScore { score: -1, comment: "".to_string(), datetime: now_with_fixed_offset() - Duration::days(25) - Duration::minutes(1) };
         let fifty_days_ago_daily_score =
-            DailyScore { score: 2, comment: "".to_string(), datetime: Local::now() - Duration::days(50) + Duration::minutes(1) };
+            DailyScore { score: 2, comment: "".to_string(), datetime: now_with_fixed_offset() - Duration::days(50) + Duration::minutes(1) };
         let ninty_days_ago_daily_score =
-            DailyScore { score: 20, comment: "".to_string(), datetime: Local::now() - Duration::days(90) };
+            DailyScore { score: 20, comment: "".to_string(), datetime: now_with_fixed_offset() - Duration::days(90) };
 
         let mood_report = MoodReport::from_daily_scores(
             vec![
@@ -147,15 +148,19 @@ mod tests {
         let daily_score = DailyScore::with_score(1);
         let another_daily_score = DailyScore::with_score(2);
         let forty_days_ago_score =
-            DailyScore { score: 5, comment: "".to_string(), datetime: Local::now() - Duration::days(40) };
+            DailyScore { score: 5, comment: "".to_string(), datetime: now_with_fixed_offset()  - Duration::days(40) };
 
         let old_score =
-            DailyScore { score: -4, datetime: Local::now() - Duration::weeks(55), comment: "".to_string() };
+            DailyScore { score: -4, datetime: now_with_fixed_offset() - Duration::weeks(55), comment: "".to_string() };
 
         let mood_report = MoodReport::from_daily_scores(
             vec![daily_score, another_daily_score, forty_days_ago_score, old_score]
         );
 
         assert_eq!(mood_report.yearly_mood(), 8);
+    }
+
+    fn now_with_fixed_offset() -> DateTime<FixedOffset> {
+        Utc::now().with_timezone(&FixedOffset::east(0))
     }
 }

--- a/src/mood_report.rs
+++ b/src/mood_report.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::Local;
 use chrono::Duration;
 
 use crate::daily_score::DailyScore;
@@ -29,13 +29,13 @@ impl MoodReport {
     }
 
     pub fn thirty_days_mood(&self) -> i32 {
-        let thirty_days_ago = Utc::now() - Duration::days(30);
+        let thirty_days_ago = Local::now() - Duration::days(30);
 
         self.filter_mood_sum(|daily_score| daily_score.datetime >= thirty_days_ago)
     }
 
     pub fn yearly_mood(&self) -> i32 {
-        let usual_year_ago = Utc::now() - Duration::days(365);
+        let usual_year_ago = Local::now() - Duration::days(365);
 
         self.filter_mood_sum(|daily_score| daily_score.datetime >= usual_year_ago)
     }
@@ -62,8 +62,8 @@ impl MoodReport {
         for frame_starts_at_days_ago in ((ends_at_days_ago + frame_size)..(starts_at_days_ago + frame_size)).rev() {
             let sum = self
                 .filter_mood_sum(|daily_score| {
-                    daily_score.datetime >= Utc::now() - Duration::days(frame_starts_at_days_ago as i64) &&
-                        daily_score.datetime <= Utc::now() - Duration::days(frame_starts_at_days_ago as i64) + Duration::days(frame_size as i64)
+                    daily_score.datetime >= Local::now() - Duration::days(frame_starts_at_days_ago as i64) &&
+                        daily_score.datetime <= Local::now() - Duration::days(frame_starts_at_days_ago as i64) + Duration::days(frame_size as i64)
                 });
             hist.push(sum);
         }
@@ -106,7 +106,7 @@ mod tests {
         let daily_score = DailyScore::with_score(1);
         let another_daily_score = DailyScore::with_score(2);
         let old_daily_score =
-            DailyScore { score: 5, comment: "".to_string(), datetime: Utc::now() - Duration::days(40) };
+            DailyScore { score: 5, comment: "".to_string(), datetime: Local::now() - Duration::days(40) };
 
         let mood_report =
             MoodReport::from_daily_scores(vec![daily_score, another_daily_score, old_daily_score]);
@@ -118,11 +118,11 @@ mod tests {
     fn thirty_days_moving_mood() {
         let today_daily_score = DailyScore::with_score(1);
         let beginning_of_month_daily_score =
-            DailyScore { score: -1, comment: "".to_string(), datetime: Utc::now() - Duration::days(25) - Duration::minutes(1) };
+            DailyScore { score: -1, comment: "".to_string(), datetime: Local::now() - Duration::days(25) - Duration::minutes(1) };
         let fifty_days_ago_daily_score =
-            DailyScore { score: 2, comment: "".to_string(), datetime: Utc::now() - Duration::days(50) + Duration::minutes(1) };
+            DailyScore { score: 2, comment: "".to_string(), datetime: Local::now() - Duration::days(50) + Duration::minutes(1) };
         let ninty_days_ago_daily_score =
-            DailyScore { score: 20, comment: "".to_string(), datetime: Utc::now() - Duration::days(90) };
+            DailyScore { score: 20, comment: "".to_string(), datetime: Local::now() - Duration::days(90) };
 
         let mood_report = MoodReport::from_daily_scores(
             vec![
@@ -147,10 +147,10 @@ mod tests {
         let daily_score = DailyScore::with_score(1);
         let another_daily_score = DailyScore::with_score(2);
         let forty_days_ago_score =
-            DailyScore { score: 5, comment: "".to_string(), datetime: Utc::now() - Duration::days(40) };
+            DailyScore { score: 5, comment: "".to_string(), datetime: Local::now() - Duration::days(40) };
 
         let old_score =
-            DailyScore { score: -4, datetime: Utc::now() - Duration::weeks(55), comment: "".to_string() };
+            DailyScore { score: -4, datetime: Local::now() - Duration::weeks(55), comment: "".to_string() };
 
         let mood_report = MoodReport::from_daily_scores(
             vec![daily_score, another_daily_score, forty_days_ago_score, old_score]

--- a/todo
+++ b/todo
@@ -15,8 +15,8 @@
 15. ✓ get rid of passing iterator to lib objects; use slices or structs
 16. ✗ think of moving CliError to separate file
 17. ✓ add and use some rust extended linter (probably clippy)
-19. use dates in timezone for mood report purposes instead of x days ago from current time
-19. add readme
-20. add optional tags
-21. add export to gnu plot
-22. add export to xcel or open office calc format
+19. ✓ use dates in timezone for mood report purposes instead of x days ago from current time
+20. add readme
+21. add optional tags
+22. add export to gnu plot
+23. add export to xcel or open office calc format


### PR DESCRIPTION
1. dates in journal file now stored in a local timezone instead of utc (timezone is still specified in a file);
2. instead of using plain time durations to determine if particular record should be counted inside mood report, use calendar dates (in local timezone).

Assume that now is 9:00 31 Jan 2020 +3:00,
and, say, we have two records in a file:
1) 10:00 1 Jan +3:00, score 1
2) 8:00 1 Jan 2020 +3:00, score -1

Earlier, monthly report would include record 1, since it was made later than strictly 30 days ago (30 * 24 hours).
Record 2 won't be included in report, because it was made 30 * 24 + 1 = 721 hours ago.
Now, none of these would be considered for a report, since report for 30 days would be report for 2-31 Jan dates.