### PR TITLE
I24/7 days iterative report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "howdy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "howdy"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Daniil Sunyaev <dasforrum@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Here:
   currently, there is no particular use of it other than making a note for yourself;
 - `REPORT_TYPE` is one of the possible report types:
   - `w` or `weekly`: sum up daily scores in Mon-Sun intervals and display those;
+  - `7d` or `seven days`: sum up daily scores in 7 days intervals (including today) and display those;
   - `m` or `monthly`: sum up daily scores for monthly intervals and display those;
   - `lm` or `last month`: sum up daily scores for last 30 days and display it;
 (if no report type is specified, the `monthly` option is considered);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ fn build_mood_command<I>(mut args: I, config: Config) -> Result<MoodCommand, Cli
         Some("y") | Some("yearly") => MoodReportType::Yearly,
         Some("mm") | Some("moving") => MoodReportType::MovingMonthly,
         Some("w") | Some("weekly") => MoodReportType::WeeklyIterative,
+        Some("7d") | Some("7 days") => MoodReportType::SevenDaysIterative,
         None => MoodReportType::Monthly,
         Some(unrecognized_option) => return Err(CliError::MoodReportTypeInvalid(unrecognized_option.to_string())),
     };

--- a/src/mood_command.rs
+++ b/src/mood_command.rs
@@ -19,6 +19,7 @@ pub struct MoodCommand {
 
 pub enum MoodReportType {
     WeeklyIterative,
+    SevenDaysIterative,
     Monthly,
     MonthlyIterative,
     Yearly,
@@ -100,6 +101,15 @@ impl MoodCommand {
             },
             MoodReportType::WeeklyIterative => {
                 let data = mood_report.iterative_weekly_mood();
+                println!("weekly moods: {:?}", data.iter().map(|ts| ts.1).collect::<Vec<i32>>());
+                if !data.is_empty() {
+                    if let Err(error) = plot::draw(&data) {
+                        println!("Warning: can't init gnuplot: {:?}", error);
+                    };
+                }
+            },
+            MoodReportType::SevenDaysIterative => {
+                let data = mood_report.iterative_seven_days_mood();
                 println!("weekly moods: {:?}", data.iter().map(|ts| ts.1).collect::<Vec<i32>>());
                 if !data.is_empty() {
                     if let Err(error) = plot::draw(&data) {

--- a/src/mood_report.rs
+++ b/src/mood_report.rs
@@ -1,7 +1,6 @@
 use chrono::{Local, Duration, Datelike, DateTime, FixedOffset};
 use std::collections::{HashSet, HashMap};
-use std::convert::TryInto;
-use std::num::TryFromIntError;
+use std::convert::TryFrom;
 
 use crate::daily_score::DailyScore;
 
@@ -134,10 +133,10 @@ impl<'a> MoodReport<'a> {
             let i_i64 = (seconds_before_report_end - 1) / period;
 
             // drop anything in the future or beyod platform's max len periods ago
-            let i_convert: Result<usize, TryFromIntError> = i_i64.try_into();
+            let i_convert = usize::try_from(i_i64);
             if i_convert.is_err() { continue };
 
-            let i: usize = i_convert.unwrap();
+            let i = i_convert.unwrap();
             let seconds_to_next_period = seconds_before_report_end % period;
 
             // potentially we can reserve data space before loop, but first record usually is the oldest,


### PR DESCRIPTION
add 7 days iterative report. Weekly report brings data in Mon-Sun intervals, this report can yield data for Tue-Mon, Sun-Sat, i.e. weekly intervals that do not necessarily and with Sun 23:59:59. 